### PR TITLE
make auto definition optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stencil/core",
-  "version": "2.8.0-1",
+  "version": "2.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@stencil/core",
-      "version": "2.8.0-1",
+      "version": "2.8.0",
       "license": "MIT",
       "bin": {
         "stencil": "bin/stencil"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stencil/core",
-  "version": "2.8.0-1",
+  "version": "2.8.0",
   "license": "MIT",
   "main": "./internal/stencil-core/index.cjs",
   "module": "./internal/stencil-core/index.js",

--- a/src/compiler/bundle/app-data-plugin.ts
+++ b/src/compiler/bundle/app-data-plugin.ts
@@ -148,12 +148,12 @@ const appendGlobalScripts = (globalScripts: GlobalScript[], s: MagicString) => {
 };
 
 const appendBuildConditionals = (config: d.Config, build: d.BuildConditionals, s: MagicString) => {
-  const builData = Object.keys(build)
+  const buildData = Object.keys(build)
     .sort()
     .map((key) => key + ': ' + ((build as any)[key] ? 'true' : 'false'))
     .join(', ');
 
-  s.append(`export const BUILD = /* ${config.fsNamespace} */ { ${builData} };\n`);
+  s.append(`export const BUILD = /* ${config.fsNamespace} */ { ${buildData} };\n`);
 };
 
 const appendEnv = (config: d.Config, s: MagicString) => {

--- a/src/compiler/output-targets/dist-custom-elements/index.ts
+++ b/src/compiler/output-targets/dist-custom-elements/index.ts
@@ -151,7 +151,7 @@ const getCustomElementBundleCustomTransformer = (
     styleImportData: 'queryparams',
   };
   return [
-    addDefineCustomElementFunctions(compilerCtx, components),
+    addDefineCustomElementFunctions(config, compilerCtx, components),
     updateStencilCoreImports(transformOpts.coreImportPath),
     nativeComponentTransform(compilerCtx, transformOpts),
     removeCollectionImports(compilerCtx),

--- a/src/compiler/output-targets/dist-custom-elements/index.ts
+++ b/src/compiler/output-targets/dist-custom-elements/index.ts
@@ -40,7 +40,12 @@ const bundleCustomElements = async (
       id: 'customElements',
       platform: 'client',
       conditionals: getCustomElementsBuildConditionals(config, buildCtx.components),
-      customTransformers: getCustomElementBundleCustomTransformer(config, compilerCtx, buildCtx.components),
+      customTransformers: getCustomElementBundleCustomTransformer(
+        config,
+        compilerCtx,
+        buildCtx.components,
+        outputTarget
+      ),
       externalRuntime: !!outputTarget.externalRuntime,
       inlineWorkers: true,
       inputs: {
@@ -139,7 +144,8 @@ const generateEntryPoint = (outputTarget: d.OutputTargetDistCustomElements, _bui
 const getCustomElementBundleCustomTransformer = (
   config: d.Config,
   compilerCtx: d.CompilerCtx,
-  components: d.ComponentCompilerMeta[]
+  components: d.ComponentCompilerMeta[],
+  outputTarget: d.OutputTargetDistCustomElements
 ) => {
   const transformOpts: d.TransformOptions = {
     coreImportPath: STENCIL_INTERNAL_CLIENT_ID,
@@ -151,7 +157,7 @@ const getCustomElementBundleCustomTransformer = (
     styleImportData: 'queryparams',
   };
   return [
-    addDefineCustomElementFunctions(config, compilerCtx, components),
+    addDefineCustomElementFunctions(compilerCtx, components, outputTarget),
     updateStencilCoreImports(transformOpts.coreImportPath),
     nativeComponentTransform(compilerCtx, transformOpts),
     removeCollectionImports(compilerCtx),

--- a/src/compiler/transformers/component-native/add-define-custom-element-function.ts
+++ b/src/compiler/transformers/component-native/add-define-custom-element-function.ts
@@ -8,15 +8,15 @@ import { addCoreRuntimeApi, RUNTIME_APIS } from '../core-runtime-apis';
 /**
  * Import and define components along with any component dependents within the `dist-custom-elements` output.
  * Adds `defineCustomElement()` function for all components.
- * @param config - the Stencil configuration file
  * @param compilerCtx - current compiler context
  * @param components - all current components within the stencil buildCtx
+ * @param outputTarget - the output target being compiled
  * @returns a TS AST transformer factory function
  */
 export const addDefineCustomElementFunctions = (
-  config: d.Config,
   compilerCtx: d.CompilerCtx,
-  components: d.ComponentCompilerMeta[]
+  components: d.ComponentCompilerMeta[],
+  outputTarget: d.OutputTargetDistCustomElements
 ): ts.TransformerFactory<ts.SourceFile> => {
   return () => {
     return (tsSourceFile: ts.SourceFile): ts.SourceFile => {
@@ -58,7 +58,7 @@ export const addDefineCustomElementFunctions = (
         setupComponentDependencies(moduleFile, components, newStatements, caseStatements, tagNames);
         addDefineCustomElementFunction(tagNames, newStatements, caseStatements);
 
-        if (config.extras?.autoDefineCustomElements) {
+        if (outputTarget.autoDefineCustomElements) {
           const conditionalDefineCustomElementCall = createAutoDefinitionExpression(
             principalComponent.componentClassName
           );

--- a/src/compiler/transformers/component-native/add-define-custom-element-function.ts
+++ b/src/compiler/transformers/component-native/add-define-custom-element-function.ts
@@ -59,7 +59,9 @@ export const addDefineCustomElementFunctions = (
         addDefineCustomElementFunction(tagNames, newStatements, caseStatements);
 
         if (config.extras?.autoDefineCustomElements) {
-          const conditionalDefineCustomElementCall = createAutoDefinitionExpression(principalComponent.componentClassName);
+          const conditionalDefineCustomElementCall = createAutoDefinitionExpression(
+            principalComponent.componentClassName
+          );
           newStatements.push(conditionalDefineCustomElementCall);
         }
       }

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -327,13 +327,6 @@ export interface ConfigExtras {
    * can be customized at runtime. Defaults to `false`.
    */
   tagNameTransform?: boolean;
-
-  /**
-   * Enables the auto-definition of a component and its children (recursively) in the custom elements registry. This
-   * functionality allows consumers to bypass the explicit call to define a component, its children, its children's
-   * children, etc. Users of this flag should be aware that enabling this functionality may increase bundle size.
-   */
-  autoDefineCustomElements?: boolean;
 }
 
 export interface Config extends StencilConfig {
@@ -1923,6 +1916,12 @@ export interface OutputTargetDistCustomElements extends OutputTargetBaseNext {
   inlineDynamicImports?: boolean;
   includeGlobalScripts?: boolean;
   minify?: boolean;
+  /**
+   * Enables the auto-definition of a component and its children (recursively) in the custom elements registry. This
+   * functionality allows consumers to bypass the explicit call to define a component, its children, its children's
+   * children, etc. Users of this flag should be aware that enabling this functionality may increase bundle size.
+   */
+  autoDefineCustomElements?: boolean;
 }
 
 export interface OutputTargetDistCustomElementsBundle extends OutputTargetBaseNext {

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -327,6 +327,13 @@ export interface ConfigExtras {
    * can be customized at runtime. Defaults to `false`.
    */
   tagNameTransform?: boolean;
+
+  /**
+   * Enables the auto-definition of a component and its children (recursively) in the custom elements registry. This
+   * functionality allows consumers to bypass the explicit call to define a component, its children, its children's
+   * children, etc. Users of this flag should be aware that enabling this functionality may increase bundle size.
+   */
+  autoDefineCustomElements?: boolean;
 }
 
 export interface Config extends StencilConfig {


### PR DESCRIPTION
With this commit, we make auto definition of custom elements optional, by hiding them behind a configuration flag (`autoDefineCustomElements`)

A small design decision here: the `BUILD.*` global variable is not available to us in code that lives in `src/compiler/*`, which is why we use the `config` file directly (or rather, the parsed/validated version of the config file).

I also reverted the version change in `package.json` I made in the last PR/commit